### PR TITLE
Fix typo in GroupBuyScreen comment

### DIFF
--- a/screens/GroupBuyScreen.tsx
+++ b/screens/GroupBuyScreen.tsx
@@ -30,7 +30,7 @@ interface ProductItem {
 }
 
 
-// 가대이터
+// 가상 데이터
 const dummyProducts: ProductItem[] = Array.from({ length: 10 }).map((_, idx) => ({
   id: `${idx}`,
   title: `전남 고흥 | 딸기`,


### PR DESCRIPTION
## Summary
- fix a small typo in a comment in `GroupBuyScreen.tsx`

## Testing
- `npx react-native --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494a97a2488322afe35c32c359ba56